### PR TITLE
SBS2-1793: Run unit tests in default root directory

### DIFF
--- a/.circleci/config-approval.yml
+++ b/.circleci/config-approval.yml
@@ -86,11 +86,10 @@ jobs:
       - checkout
       - run:
           name: Build
-          command: dotnet build
-          working_directory: << pipeline.parameters.project_name >>
+          command: dotnet build -c Release
       - run:
           name: Running Tests
-          command: dotnet test
+          command: dotnet test -c Release --logger "trx"
 
   #  other-unit-tests:
   #    ToDo

--- a/.circleci/config-approval.yml
+++ b/.circleci/config-approval.yml
@@ -91,7 +91,6 @@ jobs:
       - run:
           name: Running Tests
           command: dotnet test
-          working_directory: << pipeline.parameters.project_name >>
 
   #  other-unit-tests:
   #    ToDo

--- a/.circleci/config-automatic.yml
+++ b/.circleci/config-automatic.yml
@@ -86,11 +86,10 @@ jobs:
       - checkout
       - run:
           name: Build
-          command: dotnet build
-          working_directory: << pipeline.parameters.project_name >>
+          command: dotnet build -c Release
       - run:
           name: Running Tests
-          command: dotnet test
+          command: dotnet test -c Release --logger "trx"
 
   #  other-unit-tests:
   #    ToDo

--- a/.circleci/config-automatic.yml
+++ b/.circleci/config-automatic.yml
@@ -91,7 +91,6 @@ jobs:
       - run:
           name: Running Tests
           command: dotnet test
-          working_directory: << pipeline.parameters.project_name >>
 
   #  other-unit-tests:
   #    ToDo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,6 @@ jobs:
       - run:
           name: Running Tests
           command: dotnet test
-          working_directory: << pipeline.parameters.project_name >>
 
 workflows:
   pull_requests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,11 +21,10 @@ jobs:
       - checkout
       - run:
           name: Build
-          command: dotnet build
-          working_directory: << pipeline.parameters.project_name >>
+          command: dotnet build -c Release
       - run:
           name: Running Tests
-          command: dotnet test
+          command: dotnet test -c Release --logger "trx"
 
 workflows:
   pull_requests:


### PR DESCRIPTION
Remove working directory for dotnet test to test all test projects in root directory instead of the project directory